### PR TITLE
build workflow checkout w/o specific ref for event_name == 'release'

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout code for push or pull request
-        if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' }}
+        if: ${{ github.event_name == 'push' || github.event_name == 'release' }}
         uses: actions/checkout@v2
 
       - name: Output inputs for manual run


### PR DESCRIPTION
Fixes #197