### PR TITLE
Configure instance-manager to use base64-encoded jwt secrets

### DIFF
--- a/.github/workflows/dispatch.service-configure.yml
+++ b/.github/workflows/dispatch.service-configure.yml
@@ -46,5 +46,5 @@ jobs:
           client-payload: |
             {
               "service_id": "users",
-              "env_vars": "{\"IS_READY\": \"1\",\"JWT_SECRET_KEY\": \"{{ secrets.USERS_JWT_PRIVATE }}\",\"JWT_PUBLIC_KEY\": \"{{ secrets.USERS_JWT_PUBLIC }}\",\"JWT_PASSPHRASE\": \"{{ secrets.USERS_JWT_PASSPHRASE }}\"}"
+              "env_vars": "{\"IS_READY\": \"1\",\"JWT_SECRET_KEY_BASE64\": \"{{ secrets.USERS_JWT_SECRET_KEY_BASE64 }}\",\"JWT_PUBLIC_KEY_BASE64\": \"{{ secrets.USERS_JWT_PUBLIC_KEY_BASE64 }}\",\"JWT_PASSPHRASE\": \"{{ secrets.USERS_JWT_PASSPHRASE }}\"}"
             }


### PR DESCRIPTION
Fixes #245